### PR TITLE
Check if channel is closed

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -40,7 +40,7 @@ public class ChannelWrapper
 
     public void write(Object packet)
     {
-        if ( !closed )
+        if ( !closed && ch.isOpen() )
         {
             if ( packet instanceof PacketWrapper )
             {
@@ -58,8 +58,11 @@ public class ChannelWrapper
         if ( !closed )
         {
             closed = true;
-            ch.flush();
-            ch.close();
+            if ( ch.isOpen() )
+            {
+                ch.flush();
+                ch.close();
+            }
         }
     }
 
@@ -68,7 +71,10 @@ public class ChannelWrapper
         if ( !closed )
         {
             closed = true;
-            ch.writeAndFlush(packet).addListener(ChannelFutureListener.CLOSE);
+            if ( ch.isOpen() )
+            {
+                ch.writeAndFlush(packet).addListener(ChannelFutureListener.CLOSE);
+            }
         }
     }
 


### PR DESCRIPTION
Your patch is working fine, but it's spamming the console and log files with exceptions:
"11:11:48 [SEVERE] Dec 12, 2015 11:11:48 AM io.netty.channel.DefaultChannelPipeline$TailContext exceptionCaught
WARNING: An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception."

Testing if the channel is closed prevent these messages. Maybe you'll find a better solution with a close listener for instance.
